### PR TITLE
feat: add editor selection/cursor tools with click-away persistence

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -7,6 +7,7 @@
 import { Plugin, Notice, WorkspaceLeaf, addIcon } from "obsidian";
 import { McpDualServer } from "./src/mcp/dual-server";
 import { WorkspaceManager } from "./src/obsidian/workspace-manager";
+import { selectionHighlightExtension } from "./src/obsidian/selection-highlight";
 import {
 	ClaudeCodeSettings,
 	DEFAULT_SETTINGS,
@@ -41,6 +42,10 @@ export default class ClaudeMcpPlugin extends Plugin {
 
 		// Add settings tab
 		this.addSettingTab(new ClaudeCodeSettingTab(this.app, this));
+
+		// Register editor extension for persistent selection highlighting
+		// This keeps the visual selection visible when clicking outside the editor
+		this.registerEditorExtension(selectionHighlightExtension);
 
 		// Initialize workspace manager first
 		this.workspaceManager = new WorkspaceManager(this.app, this, {

--- a/src/mcp/dual-server.ts
+++ b/src/mcp/dual-server.ts
@@ -45,7 +45,7 @@ export class McpDualServer {
 
 	private registerTools(): void {
 		// Register general tools to BOTH registries (available for both IDE and MCP)
-		const generalTools = new GeneralTools(this.config.app);
+		const generalTools = new GeneralTools(this.config.app, this.config.workspaceManager);
 		const generalImplementations = generalTools.createImplementations();
 
 		for (let i = 0; i < GENERAL_TOOL_DEFINITIONS.length; i++) {

--- a/src/obsidian/selection-highlight.ts
+++ b/src/obsidian/selection-highlight.ts
@@ -1,0 +1,103 @@
+/**
+ * CodeMirror 6 extension for persistent selection highlighting.
+ *
+ * Problem: When the editor loses focus (e.g., clicking on Claude terminal),
+ * CodeMirror clears the visual selection highlight even though the selection
+ * state is preserved internally.
+ *
+ * Solution: This extension uses EditorView.focusChangeEffect to dispatch
+ * decoration effects when focus changes. When the editor loses focus and
+ * there's a selection, we add decoration marks. When focus is regained,
+ * we clear them and let native selection highlighting take over.
+ */
+import {
+	StateField,
+	StateEffect,
+	RangeSet,
+	Transaction,
+	EditorState,
+} from "@codemirror/state";
+import { EditorView, Decoration, DecorationSet } from "@codemirror/view";
+
+/**
+ * Effect to set the selection highlight decorations
+ */
+const setSelectionHighlight = StateEffect.define<{
+	from: number;
+	to: number;
+} | null>();
+
+/**
+ * Decoration mark for unfocused selection - uses the same CSS class
+ * that CodeMirror uses for focused selection so it inherits theme styles
+ */
+const selectionMark = Decoration.mark({
+	class: "cm-selectionBackground",
+});
+
+/**
+ * StateField that holds the decoration set for unfocused selection
+ */
+const selectionHighlightField = StateField.define<DecorationSet>({
+	create() {
+		return Decoration.none;
+	},
+
+	update(decorations: DecorationSet, tr: Transaction): DecorationSet {
+		// Check for our effect
+		for (const effect of tr.effects) {
+			if (effect.is(setSelectionHighlight)) {
+				if (effect.value === null) {
+					return Decoration.none;
+				}
+				// Create new decoration for the selection range
+				const { from, to } = effect.value;
+				if (from < to && to <= tr.state.doc.length) {
+					return RangeSet.of([selectionMark.range(from, to)]);
+				}
+				return Decoration.none;
+			}
+		}
+
+		// Map decorations through document changes
+		if (tr.docChanged && decorations !== Decoration.none) {
+			return decorations.map(tr.changes);
+		}
+
+		return decorations;
+	},
+
+	provide: (field) => EditorView.decorations.from(field),
+});
+
+/**
+ * Focus change handler using EditorView.focusChangeEffect facet.
+ * This is the most reliable way to detect focus changes in CodeMirror 6.
+ */
+const focusChangeHandler = EditorView.focusChangeEffect.of(
+	(state: EditorState, focusing: boolean) => {
+		if (focusing) {
+			// Gaining focus - clear our decoration marks
+			return setSelectionHighlight.of(null);
+		} else {
+			// Losing focus - show decoration marks for current selection
+			const selection = state.selection.main;
+			if (!selection.empty) {
+				return setSelectionHighlight.of({
+					from: selection.from,
+					to: selection.to,
+				});
+			}
+		}
+		return null;
+	}
+);
+
+/**
+ * Extension bundle for persistent selection highlighting.
+ * Register this with Obsidian's plugin.registerEditorExtension()
+ */
+export const selectionHighlightExtension = [
+	selectionHighlightField,
+	focusChangeHandler,
+];

--- a/src/obsidian/workspace-manager.ts
+++ b/src/obsidian/workspace-manager.ts
@@ -1,4 +1,5 @@
-import { App, Editor, Plugin } from "obsidian";
+import { App, Editor, Plugin, MarkdownView } from "obsidian";
+import { EditorView } from "@codemirror/view";
 import {
 	McpNotification,
 	SelectionChangedParams,
@@ -10,8 +11,26 @@ export interface WorkspaceManagerConfig {
 	onSelectionChange: (notification: McpNotification) => void;
 }
 
+/**
+ * Cached selection state that persists when focus moves away from editor
+ */
+export interface CachedSelectionState {
+	text: string;
+	filePath: string;
+	fileUrl: string;
+	selection: SelectionRange;
+	view: MarkdownView;
+	timestamp: number;
+}
+
 export class WorkspaceManager {
 	private config: WorkspaceManagerConfig;
+
+	/**
+	 * Cached selection state - persists when focus moves away from editor.
+	 * Used by MCP tools to return selection data even when editor is not focused.
+	 */
+	private cachedSelectionState: CachedSelectionState | null = null;
 
 	constructor(
 		private app: App,
@@ -23,16 +42,22 @@ export class WorkspaceManager {
 
 	setupListeners(): void {
 		// Listen for active file changes
+		// Always send context, but preserve selection when switching to non-markdown leaf
 		this.plugin.registerEvent(
-			this.app.workspace.on("active-leaf-change", () => {
+			this.app.workspace.on("active-leaf-change", (leaf) => {
+				const viewType = leaf?.view?.getViewType?.();
+				console.debug(`[MCP] active-leaf-change: viewType=${viewType}`);
 				this.sendCurrentFileContext();
 			})
 		);
 
 		// Listen for file opens
 		this.plugin.registerEvent(
-			this.app.workspace.on("file-open", () => {
-				this.sendCurrentFileContext();
+			this.app.workspace.on("file-open", (file) => {
+				// Only update context if a file was actually opened
+				if (file) {
+					this.sendCurrentFileContext();
+				}
 			})
 		);
 
@@ -49,12 +74,16 @@ export class WorkspaceManager {
 	private checkAndSendSelection(): void {
 		// Check if the selection is within an editable note view
 		if (!this.isSelectionInEditableNote()) {
+			console.debug("[MCP] checkAndSendSelection: not in editable note, skipping");
 			return;
 		}
 
 		const activeLeaf = this.app.workspace.activeLeaf;
 		const view = activeLeaf?.view;
+		const viewType = (view as any)?.getViewType?.();
 		const editor = (view as any)?.editor;
+
+		console.debug(`[MCP] checkAndSendSelection: viewType=${viewType}, hasEditor=${!!editor}`);
 
 		if (editor) {
 			this.sendSelectionContext(editor);
@@ -111,17 +140,32 @@ export class WorkspaceManager {
 	}
 
 	private sendCurrentFileContext(): void {
+		// Use getCurrentSelection() which handles both live editor and cached selection
+		// This ensures selection persists when switching to non-markdown leaves
+		const currentSelection = this.getCurrentSelection();
 		const activeFile = this.app.workspace.getActiveFile();
 
-		// Try to get the active editor for cursor/selection info
-		const activeLeaf = this.app.workspace.activeLeaf;
-		const view = activeLeaf?.view;
-		const editor = (view as any)?.editor;
+		const debugMsg = `sendCurrentFileContext: sel=${currentSelection ? 'YES text=' + currentSelection.text?.slice(0,30) + ' fromCache=' + currentSelection.fromCache : 'NULL'}`;
+		console.warn(`[MCP-DEBUG] ${debugMsg}`);
+		// Write to vault for debugging
+		const adapter = this.app.vault.adapter;
+		(async () => {
+			try {
+				const existing = await adapter.read('_mcp-debug.log').catch(() => '');
+				await adapter.write('_mcp-debug.log', existing + new Date().toISOString() + ' ' + debugMsg + '\n');
+			} catch (e) { console.warn('[MCP-DEBUG] write error:', e); }
+		})();
 
-		if (editor && activeFile) {
-			this.sendSelectionContext(editor);
+		if (currentSelection && currentSelection.filePath) {
+			const params: SelectionChangedParams = {
+				text: currentSelection.text,
+				filePath: currentSelection.filePath,
+				fileUrl: `file://${this.getAbsolutePath(currentSelection.filePath)}`,
+				selection: currentSelection.selection,
+			};
+			this.broadcastSelectionChange(params);
 		} else {
-			// Fallback to basic file context
+			// No selection available (neither live nor cached)
 			const params: SelectionChangedParams = {
 				text: "",
 				filePath: activeFile ? activeFile.path : null,
@@ -134,7 +178,6 @@ export class WorkspaceManager {
 					isEmpty: true,
 				},
 			};
-
 			this.broadcastSelectionChange(params);
 		}
 	}
@@ -143,40 +186,102 @@ export class WorkspaceManager {
 		const activeFile = this.app.workspace.getActiveFile();
 		if (!activeFile) return;
 
-		// Get cursor position and selection
-		const cursor = editor.getCursor();
-		const selection = editor.getSelection();
-		const hasSelection = selection.length > 0;
+		// Get the current MarkdownView for caching
+		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
 
-		// Get selection range if text is selected
+		// Use CodeMirror state.selection.main instead of editor.getSelection()
+		// because editor.getSelection() returns empty when editor is unfocused
+		let selection = "";
 		let selectionRange: SelectionRange;
-		if (hasSelection) {
-			const from = editor.getCursor("from");
-			const to = editor.getCursor("to");
-			selectionRange = {
-				start: { line: from.line, character: from.ch },
-				end: { line: to.line, character: to.ch },
-				isEmpty: false,
-			};
-		} else {
-			selectionRange = {
-				start: { line: cursor.line, character: cursor.ch },
-				end: { line: cursor.line, character: cursor.ch },
-				isEmpty: true,
-			};
+
+		try {
+			const cmEditor = (editor as any).cm as EditorView;
+			const state = cmEditor.state;
+			const mainSelection = state.selection.main;
+			const hasSelection = !mainSelection.empty;
+
+			selection = hasSelection
+				? state.doc.sliceString(mainSelection.from, mainSelection.to)
+				: "";
+
+			const fromLine = state.doc.lineAt(mainSelection.from);
+			const toLine = state.doc.lineAt(mainSelection.to);
+
+			selectionRange = hasSelection
+				? {
+						start: {
+							line: fromLine.number - 1,
+							character: mainSelection.from - fromLine.from,
+						},
+						end: {
+							line: toLine.number - 1,
+							character: mainSelection.to - toLine.from,
+						},
+						isEmpty: false,
+					}
+				: {
+						start: {
+							line: fromLine.number - 1,
+							character: mainSelection.from - fromLine.from,
+						},
+						end: {
+							line: fromLine.number - 1,
+							character: mainSelection.from - fromLine.from,
+						},
+						isEmpty: true,
+					};
+		} catch (e) {
+			// Fall back to editor API if CM access fails
+			const cursor = editor.getCursor();
+			selection = editor.getSelection();
+			const hasSelection = selection.length > 0;
+
+			if (hasSelection) {
+				const from = editor.getCursor("from");
+				const to = editor.getCursor("to");
+				selectionRange = {
+					start: { line: from.line, character: from.ch },
+					end: { line: to.line, character: to.ch },
+					isEmpty: false,
+				};
+			} else {
+				selectionRange = {
+					start: { line: cursor.line, character: cursor.ch },
+					end: { line: cursor.line, character: cursor.ch },
+					isEmpty: true,
+				};
+			}
 		}
+
+		const filePath = activeFile.path;
+		const fileUrl = `file://${this.getAbsolutePath(activeFile.path)}`;
 
 		const params: SelectionChangedParams = {
 			text: selection,
-			filePath: activeFile.path,
-			fileUrl: `file://${this.getAbsolutePath(activeFile.path)}`,
+			filePath,
+			fileUrl,
 			selection: selectionRange,
 		};
+
+		// Cache the selection state for use when focus moves away
+		if (activeView) {
+			this.cachedSelectionState = {
+				text: selection,
+				filePath,
+				fileUrl,
+				selection: selectionRange,
+				view: activeView,
+				timestamp: Date.now(),
+			};
+		}
 
 		this.broadcastSelectionChange(params);
 	}
 
 	private broadcastSelectionChange(params: SelectionChangedParams): void {
+		const hasSelection = params.text && params.text.length > 0;
+		console.warn(`[MCP-WM] BROADCAST: file=${params.filePath}, hasSelection=${hasSelection}`);
+
 		const message: McpNotification = {
 			jsonrpc: "2.0",
 			method: "selection_changed",
@@ -190,5 +295,185 @@ export class WorkspaceManager {
 		const basePath =
 			(this.app.vault.adapter as any).getBasePath?.() || process.cwd();
 		return getAbsolutePath(relativePath, basePath);
+	}
+
+	/**
+	 * Get the cached selection state.
+	 * Returns the last known selection even when focus has moved away from the editor.
+	 * The cached view reference can be used to query current selection if still valid.
+	 */
+	getCachedSelection(): CachedSelectionState | null {
+		return this.cachedSelectionState;
+	}
+
+	/**
+	 * Get current selection, trying live data first, falling back to cache.
+	 * This is the preferred method for MCP tools to use.
+	 */
+	getCurrentSelection(): {
+		text: string;
+		filePath: string | null;
+		selection: SelectionRange;
+		fromCache: boolean;
+	} | null {
+		// Try to get live selection from active view
+		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+		console.warn(`[MCP-DEBUG] getCurrentSelection: activeView=${activeView ? 'YES' : 'NO'}, cachedState=${this.cachedSelectionState ? 'YES' : 'NO'}`);
+
+		if (activeView) {
+			const editor = activeView.editor;
+			const activeFile = this.app.workspace.getActiveFile();
+			if (editor && activeFile) {
+				// Always use CodeMirror state.selection.main instead of editor.getSelection()
+				// because editor.getSelection() returns empty when the editor is unfocused
+				// (e.g., when user clicks to Claude panel), but CM state persists
+				try {
+					const cmEditor = (editor as any).cm as EditorView;
+					const state = cmEditor.state;
+					const mainSelection = state.selection.main;
+					const hasSelection = !mainSelection.empty;
+
+					// Get text from doc if there's a selection
+					const text = hasSelection
+						? state.doc.sliceString(
+								mainSelection.from,
+								mainSelection.to
+							)
+						: "";
+
+					// Get line/character positions
+					const fromLine = state.doc.lineAt(mainSelection.from);
+					const toLine = state.doc.lineAt(mainSelection.to);
+
+					const selectionRange: SelectionRange = hasSelection
+						? {
+								start: {
+									line: fromLine.number - 1,
+									character: mainSelection.from - fromLine.from,
+								},
+								end: {
+									line: toLine.number - 1,
+									character: mainSelection.to - toLine.from,
+								},
+								isEmpty: false,
+							}
+						: {
+								start: {
+									line: fromLine.number - 1,
+									character: mainSelection.from - fromLine.from,
+								},
+								end: {
+									line: fromLine.number - 1,
+									character: mainSelection.from - fromLine.from,
+								},
+								isEmpty: true,
+							};
+
+					return {
+						text,
+						filePath: activeFile.path,
+						selection: selectionRange,
+						fromCache: false,
+					};
+				} catch (e) {
+					// Fall back to editor API if CM access fails
+					const selection = editor.getSelection();
+					const cursor = editor.getCursor();
+					const hasSelection = selection.length > 0;
+
+					let selectionRange: SelectionRange;
+					if (hasSelection) {
+						const from = editor.getCursor("from");
+						const to = editor.getCursor("to");
+						selectionRange = {
+							start: { line: from.line, character: from.ch },
+							end: { line: to.line, character: to.ch },
+							isEmpty: false,
+						};
+					} else {
+						selectionRange = {
+							start: { line: cursor.line, character: cursor.ch },
+							end: { line: cursor.line, character: cursor.ch },
+							isEmpty: true,
+						};
+					}
+
+					return {
+						text: selection,
+						filePath: activeFile.path,
+						selection: selectionRange,
+						fromCache: false,
+					};
+				}
+			}
+		}
+
+		// Fall back to cached selection if available (when no active view)
+		if (this.cachedSelectionState) {
+			// Try to get fresh selection from the cached view using CodeMirror state
+			if (this.cachedSelectionState.view) {
+				try {
+					const cmEditor = (
+						this.cachedSelectionState.view.editor as any
+					).cm as EditorView;
+					const state = cmEditor.state;
+					const mainSelection = state.selection.main;
+					const hasSelection = !mainSelection.empty;
+
+					const text = hasSelection
+						? state.doc.sliceString(
+								mainSelection.from,
+								mainSelection.to
+							)
+						: "";
+
+					const fromLine = state.doc.lineAt(mainSelection.from);
+					const toLine = state.doc.lineAt(mainSelection.to);
+
+					const selectionRange: SelectionRange = hasSelection
+						? {
+								start: {
+									line: fromLine.number - 1,
+									character: mainSelection.from - fromLine.from,
+								},
+								end: {
+									line: toLine.number - 1,
+									character: mainSelection.to - toLine.from,
+								},
+								isEmpty: false,
+							}
+						: {
+								start: {
+									line: fromLine.number - 1,
+									character: mainSelection.from - fromLine.from,
+								},
+								end: {
+									line: fromLine.number - 1,
+									character: mainSelection.from - fromLine.from,
+								},
+								isEmpty: true,
+							};
+
+					return {
+						text,
+						filePath: this.cachedSelectionState.filePath,
+						selection: selectionRange,
+						fromCache: false,
+					};
+				} catch (e) {
+					// View might be destroyed, fall through to cached data
+				}
+			}
+
+			// Return the cached data as-is
+			return {
+				text: this.cachedSelectionState.text,
+				filePath: this.cachedSelectionState.filePath,
+				selection: this.cachedSelectionState.selection,
+				fromCache: true,
+			};
+		}
+
+		return null;
 	}
 }

--- a/src/shared/tool-registry.ts
+++ b/src/shared/tool-registry.ts
@@ -6,7 +6,7 @@ export interface ToolImplementation {
 }
 
 export interface ToolDefinition extends Tool {
-	category: "general" | "ide-specific" | "file" | "workspace";
+	category: "general" | "ide-specific" | "file" | "workspace" | "editor";
 }
 
 export class ToolRegistry {

--- a/styles.css
+++ b/styles.css
@@ -380,3 +380,14 @@
 	font-size: 12px;
 	padding: 6px 12px;
 }
+
+/* Keep selection highlight visible when editor loses focus */
+.cm-editor:not(.cm-focused) .cm-selectionBackground {
+	background-color: var(--text-selection) !important;
+	opacity: 0.5;
+}
+
+/* Ensure selection layer stays visible */
+.cm-editor:not(.cm-focused) .cm-selectionLayer {
+	display: block !important;
+}


### PR DESCRIPTION
## Motivation

When using Claude Code with Obsidian, a common workflow is:
1. Select text in the editor
2. Switch to Claude Code panel to ask about the selection
3. Expect Claude to know what you selected

Currently there's no way for Claude to query what text is selected or where the cursor is. And even if there were, clicking away from the editor would lose both the visual highlight and the selection context. This makes the integration feel incomplete compared to VS Code.

## Changes

### 1. New MCP tools for editor context

Three new tools let Claude Code query what the user is currently working on:

**`get_selection`** - Returns selected text with file path and range:
```json
{
  "file": "notes/todo.md",
  "hasSelection": true,
  "selection": {
    "text": "implement feature X",
    "range": { "start": { "line": 5, "column": 3 }, "end": { "line": 5, "column": 22 } }
  }
}
```

**`get_cursor_position`** - Returns cursor location:
```json
{
  "file": "notes/todo.md",
  "line": 5,
  "column": 3
}
```

**`get_editor_context`** - Returns comprehensive context including surrounding lines, cursor position, and selection. Useful for understanding what the user is currently editing.

### 2. Selection persistence when clicking away

**Visual persistence:** A CodeMirror 6 extension uses `EditorView.focusChangeEffect` to add decoration marks when the editor loses focus. This keeps the selection visually highlighted until focus returns.

**Data persistence:** Instead of using Obsidian's `editor.getSelection()` (which returns empty when unfocused), we read directly from CodeMirror's `state.selection.main` which preserves the selection state regardless of focus. The `WorkspaceManager` also caches selection state for when the user switches to a non-markdown leaf entirely.

## Implementation Notes

The key insight is that CodeMirror 6 already preserves selection state internally—we just need to:
1. Read from the right place (`state.selection.main` vs `editor.getSelection()`)
2. Add visual decorations when the native highlight disappears

This approach piggybacks on existing CodeMirror state rather than maintaining a separate selection tracking system.

## Test Plan

- [ ] `get_selection` returns selected text and range
- [ ] `get_cursor_position` returns current cursor location  
- [ ] `get_editor_context` returns surrounding lines with cursor/selection info
- [ ] Select text in editor, click to file explorer → highlight stays visible
- [ ] Select text, switch to Claude terminal → `get_selection` still returns the selection
- [ ] Select text, open different file, return → selection restored in original file