### PR TITLE
fix: handle UTF-8 multi-byte character corruption in MCP transports

### DIFF
--- a/src/mcp/http-server.ts
+++ b/src/mcp/http-server.ts
@@ -1,5 +1,6 @@
 import * as http from "http";
 import * as crypto from "crypto";
+
 import { McpRequest, McpResponse, McpNotification } from "./types";
 
 interface HttpReplyFunction {
@@ -202,7 +203,7 @@ export class McpHttpServer {
 
 		// Set SSE headers
 		res.writeHead(200, {
-			"Content-Type": "text/event-stream",
+			"Content-Type": "text/event-stream; charset=utf-8",
 			"Cache-Control": "no-cache",
 			Connection: "keep-alive",
 			"Access-Control-Allow-Origin": "*",
@@ -358,12 +359,21 @@ export class McpHttpServer {
 
 	private async readRequestBody(req: http.IncomingMessage): Promise<string> {
 		return new Promise((resolve, reject) => {
-			let body = "";
-			req.on("data", (chunk) => {
-				body += chunk.toString();
+			const chunks: Buffer[] = [];
+			req.on("data", (chunk: Buffer | string) => {
+				// In Electron/Obsidian, chunks may arrive as pre-decoded strings
+				// instead of raw Buffers, which corrupts multi-byte UTF-8 chars
+				// at chunk boundaries. Always ensure we work with raw Buffers.
+				if (Buffer.isBuffer(chunk)) {
+					chunks.push(chunk);
+				} else {
+					chunks.push(Buffer.from(chunk, "binary"));
+				}
 			});
 			req.on("end", () => {
-				resolve(body);
+				// Decode the complete buffer as UTF-8 in one pass,
+				// so no multi-byte character can be split across chunks.
+				resolve(Buffer.concat(chunks).toString("utf8"));
 			});
 			req.on("error", reject);
 		});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -34,7 +34,11 @@ export class McpServer {
 			console.debug(`[MCP] Total connected clients: ${this.connectedClients.size}`);
 
 			sock.on("message", (data) => {
-				this.handleMessage(sock, data.toString());
+				// Ensure proper UTF-8 decoding for multi-byte characters
+				const message = Buffer.isBuffer(data)
+					? data.toString("utf8")
+					: data.toString();
+				this.handleMessage(sock, message);
 			});
 
 			sock.on("close", () => {


### PR DESCRIPTION
Chunks arriving from HTTP requests or WebSocket messages may split multi-byte UTF-8 characters at chunk boundaries. Concatenating them as strings corrupts those characters. This fix collects raw Buffers and decodes the complete payload in one pass for both HTTP/SSE and WebSocket transports.